### PR TITLE
Update ibflex to @master

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ python_requires = >=3.10
 install_requires =
     beancount>=2.3.5
     requests>=2.28.2,<3.0
-    ibflex @ git+https://github.com/csingley/ibflex.git@0.16
+    ibflex @ git+https://github.com/csingley/ibflex.git@master
     openpyxl>=3.1.2,<4.0
     xlrd>=2.0.1,<3.0
     beangulp @ git+https://github.com/beancount/beangulp.git@master


### PR DESCRIPTION
The latest version of ibflex (0.16) is outdated and does not work with the recent flex reports. 
The master version does include the required fixes. 